### PR TITLE
Move some functions into sdsc.tokens

### DIFF
--- a/src/sdsc/__init__.py
+++ b/src/sdsc/__init__.py
@@ -32,6 +32,15 @@ import webbrowser
 
 from lxml import etree
 from .cli import printcolor, parseargs
+from .tokens import (counttokens,
+                     findtagreplacement,
+                     linenumber,
+                     re_compile,
+                     removepunctuation,
+                     sanitizepunctuation,
+                     tokenizer
+                     )
+
 
 # Global flags
 flag_performance = False
@@ -60,141 +69,12 @@ lastsentenceends = re.compile(r'(?<![Ee]\.g|etc|[Ii]\.e|.ca|[Nn]\.[Bb]|[Ii]nc)(?
 emptysubpattern = re.compile(r'(?<!\\)(\|\)|\(\||\|\|)')
 
 
-re_cache = {}
-
-
-def re_compile(pattern, flags=0):
-    """re.compile caches only a small number of regular expressions. Our
-    version can cache a much larger number of them which increases speed
-    since expressions do not have to be recompiled all the time.
-    """
-
-    try:
-        return re_cache[flags][pattern]
-    except KeyError:
-        if flags not in re_cache:
-            re_cache[flags] = {}
-        re_cache[flags][pattern] = re.compile(pattern, flags)
-
-        return re_cache[flags][pattern]
-
-
-def linenumber(context):
-    """ Find out line number from the source document. This is currently buggy
-    for two reasons:
-    1. libxml uses the wrong data type to provide this number which means that
-       we only get to around 65000 lines or so, which is often too little.
-    2. Line numbers in the profiled XML bigfile have little to do with the
-       original line numbers.
-    Nevertheless, this line number is added to the output but later hidden
-    via CSS.
-    """
-
-    return context.context_node.sourceline
-
-
-def removepunctuation(word, start=False, end=False):
-    """Removes punctuation from beginning/end of tokens (i.e. does not
-    expect sentences!).
-
-    Parameters:
-    text  - str(), token that we want to look at
-    start  - bool(): remove punctuation from start of token?
-    apos   - bool(): remove punctuation from end of token?
-    """
-
-    if isinstance(word, list):
-        if start:
-            word = [removepunctuation(word[0], start=True)] + word[1:]
-        if end:
-            word = word[:-1] + [removepunctuation(word[-1], end=True)]
-        return word
-
-    startpunctuation = '([{"\'¡¿<“„‟‘‚‛「『【〚〖〘〔〈《'
-    endpunctuation = '〉》〕〙〗〛】”’‛」』>)]}/\\"\',:;!?.‥…‼‽⁇⁈⁉'
-
-    if start:
-        word = word.lstrip(startpunctuation)
-    if end:
-        word = word.rstrip(endpunctuation)
-    return word
-
-
-def sanitizepunctuation(text, quotes=False, apostrophes=False):
-    """Ensures that we always work on the same kind of quotes and apostrophes.
-
-    Parameters:
-    text   - str() of text that we want to look at
-    quotes - bool(): quotes should quotes be sanitized?
-    apos   - bool(): quotes should apostrophes be sanitized?
-    """
-
-    if quotes:
-        # FIXME: In enough cases, using this will lose the information whether this
-        # was a opening quote or a closing quote.
-        # Replace quotes only if they are at start/end of a word.
-
-        quote = re_compile(r'((?<=^)[«»‹›“”„‟‘’‚‛「」『』](?=[\w\d])|(?<=\s)[«»‹›“”„‟‘’‚‛「」『』](?=[a-z0-9])|(?<=[\w\d])[«»‹›“”„‟‘’‚‛「」『』](?=$|[^\w\d]))', re.I)
-        # I need the quote_before version additionally because look-behinds must
-        # be fixed-length -- it is expensive to try to be correct. Bah.
-        quote_before = re_compile(r'((?<=[^\w\d])[«»‹›“”„‟‘’‚‛「」『』](?=[\w\d])|(?<=\s)[«»‹›“”„‟‘’‚‛「」『』](?=[a-z0-9]))', re.I)
-        text = quote.sub('"', text)
-        text = quote_before.sub('"', text)
-    if apostrophes:
-        apostrophe = re_compile(r'[’՚\'ʼ＇｀̀́`´ʻʹʽ]')
-        text = apostrophe.sub('\'', text)
-    return text
-
-def findtagreplacement(text):
-    """Search through a token to see whether it contains a replaced tag.
-    Allows finding a single tag replacement only.
-
-    text - str(): a token
-    """
-
-    tagfound = False
-    tagtype = None
-    tokens = 1
-
-    tagreplacement = re_compile(r'##@(\w+)-(\d+)##')
-    tagsreplaced = tagreplacement.search(text)
-
-    if tagsreplaced:
-        tagfound = True
-        tagtype = str(tagsreplaced.group(1))
-        tokens = int(tagsreplaced.group(2))
-
-    return (tagfound, tagtype, tokens)
-
-
-def tokenizer(text):
-    """Splits a string into a list of words.
-
-    :param str text: text to split into tokens
-    """
-    return text.split()
-
-
-def counttokens(context, text):
-    """Counts the number of tokens in a given string. This
-    is used to enable tag replacement for content that needs
-    to be skipped and conversely to re-insert skipped text and
-    enable highlighting.
-
-    :param str context: context node (ignored)
-    :param str text: text in which to count tokens
-    """
-    del context  # not used
-    count = 0
-    if text:
-        count = len(tokenizer(text[0]))
-    return count
 
 
 def sentencesegmenter(text):
     """Splits a paragraph into a list of sentences. Removes
     final punctuation from all sentences.
- 
+
     :param str text: text to split into sentences
     """
     sentences = sentenceends.split(text)

--- a/src/sdsc/tokens.py
+++ b/src/sdsc/tokens.py
@@ -1,0 +1,152 @@
+#
+# Copyright (c) 2017 SUSE Linux GmbH
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+#
+
+import re
+
+
+
+RE_CACHE = {}
+
+def re_compile(pattern, flags=0):
+    """re.compile caches only a small number of regular expressions. Our
+    version can cache a much larger number of them which increases speed
+    since expressions do not have to be recompiled all the time.
+    """
+
+    try:
+        return RE_CACHE[flags][pattern]
+    except KeyError:
+        if flags not in RE_CACHE:
+            RE_CACHE[flags] = {}
+        RE_CACHE[flags][pattern] = re.compile(pattern, flags)
+
+        return RE_CACHE[flags][pattern]
+
+
+def linenumber(context):
+    """ Find out line number from the source document. This is currently buggy
+    for two reasons:
+    1. libxml uses the wrong data type to provide this number which means that
+       we only get to around 65000 lines or so, which is often too little.
+    2. Line numbers in the profiled XML bigfile have little to do with the
+       original line numbers.
+    Nevertheless, this line number is added to the output but later hidden
+    via CSS.
+    """
+
+    return context.context_node.sourceline
+
+
+def removepunctuation(word, start=False, end=False):
+    """Removes punctuation from beginning/end of tokens (i.e. does not
+    expect sentences!).
+
+    Parameters:
+    text  - str(), token that we want to look at
+    start  - bool(): remove punctuation from start of token?
+    apos   - bool(): remove punctuation from end of token?
+    """
+
+    if isinstance(word, list):
+        if start:
+            word = [removepunctuation(word[0], start=True)] + word[1:]
+        if end:
+            word = word[:-1] + [removepunctuation(word[-1], end=True)]
+        return word
+
+    startpunctuation = '([{"\'¡¿<“„‟‘‚‛「『【〚〖〘〔〈《'
+    endpunctuation = '〉》〕〙〗〛】”’‛」』>)]}/\\"\',:;!?.‥…‼‽⁇⁈⁉'
+
+    if start:
+        word = word.lstrip(startpunctuation)
+    if end:
+        word = word.rstrip(endpunctuation)
+    return word
+
+
+def sanitizepunctuation(text, quotes=False, apostrophes=False):
+    """Ensures that we always work on the same kind of quotes and apostrophes.
+
+    Parameters:
+    text   - str() of text that we want to look at
+    quotes - bool(): quotes should quotes be sanitized?
+    apos   - bool(): quotes should apostrophes be sanitized?
+    """
+
+    if quotes:
+        # FIXME: In enough cases, using this will lose the information whether this
+        # was a opening quote or a closing quote.
+        # Replace quotes only if they are at start/end of a word.
+
+        quote = re_compile(r'((?<=^)[«»‹›“”„‟‘’‚‛「」『』](?=[\w\d])|(?<=\s)[«»‹›“”„‟‘’‚‛「」『』](?=[a-z0-9])|(?<=[\w\d])[«»‹›“”„‟‘’‚‛「」『』](?=$|[^\w\d]))', re.I)
+        # I need the quote_before version additionally because look-behinds must
+        # be fixed-length -- it is expensive to try to be correct. Bah.
+        quote_before = re_compile(r'((?<=[^\w\d])[«»‹›“”„‟‘’‚‛「」『』](?=[\w\d])|(?<=\s)[«»‹›“”„‟‘’‚‛「」『』](?=[a-z0-9]))', re.I)
+        text = quote.sub('"', text)
+        text = quote_before.sub('"', text)
+    if apostrophes:
+        apostrophe = re_compile(r'[’՚\'ʼ＇｀̀́`´ʻʹʽ]')
+        text = apostrophe.sub('\'', text)
+    return text
+
+
+def findtagreplacement(text):
+    """Search through a token to see whether it contains a replaced tag.
+    Allows finding a single tag replacement only.
+
+    text - str(): a token
+    """
+
+    tagfound = False
+    tagtype = None
+    tokens = 1
+
+    tagreplacement = re_compile(r'##@(\w+)-(\d+)##')
+    tagsreplaced = tagreplacement.search(text)
+
+    if tagsreplaced:
+        tagfound = True
+        tagtype = str(tagsreplaced.group(1))
+        tokens = int(tagsreplaced.group(2))
+
+    return (tagfound, tagtype, tokens)
+
+
+def tokenizer(text):
+    """Splits a string into a list of words.
+
+    :param str text: text to split into tokens
+    """
+    return text.split()
+
+
+def counttokens(context, text):
+    """Counts the number of tokens in a given string. This
+    is used to enable tag replacement for content that needs
+    to be skipped and conversely to re-insert skipped text and
+    enable highlighting.
+
+    :param str context: context node (ignored)
+    :param str text: text in which to count tokens
+    """
+    del context  # not used
+    count = 0
+    if text:
+        count = len(tokenizer(text[0]))
+    return count
+

--- a/tests/test_sanitizepunctuation.py
+++ b/tests/test_sanitizepunctuation.py
@@ -1,7 +1,8 @@
 #
 
 import pytest
-import sdsc
+from sdsc.tokens import sanitizepunctuation
+
 
 @pytest.mark.parametrize("params,result",
   (
@@ -21,4 +22,4 @@ import sdsc
 )
 def test_sanitizepunctuation(params,result):
     """checks whether punctuation is properly sanitized (i.e. whether quotes and apostrophes are removed properly)"""
-    assert sdsc.sanitizepunctuation(*params) == result
+    assert sanitizepunctuation(*params) == result

--- a/tests/test_tagreplacement.py
+++ b/tests/test_tagreplacement.py
@@ -1,11 +1,12 @@
 #
 
 import pytest
-import sdsc
 
 #True
 #        tagtype = str(tagsreplaced.group(1))
 #        tokens = int(tagsreplaced.group(2))
+from sdsc.tokens import findtagreplacement
+
 
 @pytest.mark.parametrize("text,result",
   (
@@ -29,4 +30,4 @@ import sdsc
 )
 def test_findtagreplacement(text,result):
     """checks whether placeholders for special tags are found"""
-    assert sdsc.findtagreplacement(text) == result
+    assert findtagreplacement(text) == result

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,7 +1,8 @@
 #
 
 import pytest
-from sdsc import tokenizer, isDupe
+from sdsc import isDupe
+from sdsc.tokens import tokenizer
 
 
 @pytest.mark.parametrize("tokens,expected",


### PR DESCRIPTION
Changes in this PR:

* re_compile
* linenumber
* removepunctuation
* sanitizepunctuation
* findtagreplacement
* tokenizer
* counttokens

Function `sentencesegmenter()` could be also refactored this way, but we need to merge #134 before we can proceed.

Goal was to reduce the line numbers in the `__init__.py` file and to separate functions which do not use global variables.

