### PR TITLE
Replace PyTest with test alias

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,9 @@ default_section=THIRDPARTY
 max-line-length = 100
 exclude = tests/*,*/migrations/*,*/south_migrations/*
 
+[aliases]
+test=pytest
+
 [tools:pytest]
 norecursedirs =
     .git

--- a/setup.py
+++ b/setup.py
@@ -20,24 +20,6 @@ __description__ = "checks a given DocBook XML file for stylistic errors"
 HERE = os.path.abspath(os.path.dirname(__file__))
 
 
-class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        #import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
-
 def read(*names, **kwargs):
     """Read in file
     """
@@ -159,11 +141,12 @@ setupdict = dict(
         'console_scripts': ['sdsc=sdsc:main'],
         },
 
-    # Required packages for testing
-    tests_require=['pytest'],
+    # Required packages for using "setup.py test"
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest', 'pytest-cov', 'pytest-catchlog'],
 
     # Actually run tests
-    cmdclass = {'test': PyTest},
+    # cmdclass = {'test': PyTest},
     )
 
 


### PR DESCRIPTION
Changes in this PR:

* Remove PyTest class and introduce an alias "test"
* You can run now the test cases with `./setup.py test`
* If you want to pass arguments to pytest, use the `--addopts` option (be aware of the quoting!)